### PR TITLE
avoid memory corruption on stack growth

### DIFF
--- a/lib/Params/Validate/XS.xs
+++ b/lib/Params/Validate/XS.xs
@@ -1748,11 +1748,15 @@ validate_with(...)
                 ret = (AV*) sv_2mortal((SV*) newAV());
             }
 
+            PUTBACK;
+
             if (! validate_pos((AV*) SvRV(params), (AV*) SvRV(spec),
             get_options(p), ret)) {
+                SPAGAIN;
                 XSRETURN(0);
             }
 
+            SPAGAIN;
             RETURN_ARRAY(ret);
         }
         else {
@@ -1802,10 +1806,14 @@ validate_with(...)
             ret = (HV*) sv_2mortal((SV*) newHV());
         }
 
+        PUTBACK;
+
         if (! validate(hv, (HV*) SvRV(spec), options, ret)) {
+            SPAGAIN;
             XSRETURN(0);
         }
 
+        SPAGAIN;
         RETURN_HASH(ret);
     }
     else {

--- a/xt/release/xs-stack-realloc.t
+++ b/xt/release/xs-stack-realloc.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN {
+    $ENV{PARAMS_VALIDATE_IMPLEMENTATION} = 'XS';
+    $ENV{PV_WARN_FAILED_IMPLEMENTATION} = 1;
+}
+
+use Params::Validate qw( validate_with );
+
+my $alloc_size; # global; used as argument to callback
+
+for my $i ( 0 .. 15 ) {
+    $alloc_size = 2**$i;
+
+    test_array_spec(undef);
+}
+
+ok(1, 'array validation succeeded with stack realloc');
+
+for my $i ( 0 .. 15 ) {
+    $alloc_size = 2**$i;
+
+    test_hash_spec( a => undef );
+}
+
+ok(1, 'hash validation succeeded with stack realloc');
+
+done_testing();
+
+sub grow_stack {
+    my @stuff = (1) x $alloc_size;
+    return 1;    # "validation" always succeeds
+}
+
+sub test_array_spec {
+    my @args = validate_with(
+        params => \@_,
+        spec   => [ { callbacks => { grow_stack => \&grow_stack } } ],
+    );
+}
+
+sub test_hash_spec {
+    my %args = validate_with(
+        params => \@_,
+        spec   => {
+            a => { callbacks => { grow_stack => \&grow_stack } },
+        },
+    );
+}


### PR DESCRIPTION
If the Perl stack is reallocated during the validate() or
validate_pos() calls in validate_with(), the return values were
being written to the old (freed) stack.

Add PUTBACK / SPAGAIN pairs around the validation calls, so that
the local and global stack pointers are kept in sync.