### PR TITLE
Fix INLINE for gcc -std=c89

### DIFF
--- a/lib/Params/Validate/XS.xs
+++ b/lib/Params/Validate/XS.xs
@@ -5,7 +5,7 @@
 #include "XSUB.h"
 #include "ppport.h"
 
-#ifdef __GNUC__
+#if (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L))
 #define INLINE inline
 #else
 #define INLINE


### PR DESCRIPTION
According to [1], the __GNUC__ macro is always defined for a gcc-compilant
compiler, whether it is in strict C standard mode or in GNU mode. This
causes the INLINE macro to always expand to "inline" on gcc/clang, even in
C89 mode where "inline" is not defined, and the module does not build.

This is fixed by replacing the check on __GNUC__ by a check on the current
version of C in use, so as to only enable "inline" when the code is
compiled in C99 (or later) mode.

[1]: https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html